### PR TITLE
Added some introductory installation instructions for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # NYC Compstat API
 
-New York City revolutionized the way cities were policed with their COMPSTAT approach. The police department releases partial reports of the data that they collect, but this information is hidden in PDF documents that disappear after a week. This service aims to provide a historical archive of these weekly compstat reports and a machine queryable interface to this data.
+New York City revolutionized the way cities were policed with their COMPSTAT
+approach. The police department releases partial reports of the data that they
+collect, but this information is hidden in PDF documents that disappear after a
+week. This service aims to provide a historical archive of these weekly
+compstat reports and a machine queryable interface to this data.
+
+## Installation Instructions
+
+### Ubuntu Installation
+
+    apt-get install rubygems libcurl4-openssl-dev libxml2-dev libxslt1-dev
+    gem install bundler
+    bundle install
+


### PR DESCRIPTION
The installation instructions in this patch don’t work 100%, they get me this far:

```
% ruby scraper.rb 

scraper.rb:4:in `require': no such file to load -- nokogiri (LoadError)
    from scraper.rb:4
```

I can get a little further with the `-rubygems` flag to ruby, which I don’t understand but:

```
% ruby -rubygems scraper.rb 

scraper.rb:16:in `build_or_set_dir': undefined method `exists?' for Dir:Class (NoMethodError)
    from scraper.rb:26:in `download_pdfs'
    from /var/lib/gems/1.8/gems/nokogiri-1.5.6/lib/nokogiri/xml/node_set.rb:239:in `each'
    from /var/lib/gems/1.8/gems/nokogiri-1.5.6/lib/nokogiri/xml/node_set.rb:238:in `upto'
    from /var/lib/gems/1.8/gems/nokogiri-1.5.6/lib/nokogiri/xml/node_set.rb:238:in `each'
    from scraper.rb:25:in `download_pdfs'
    from scraper.rb:97
```
